### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   "require": {
     "craftcms/cms": "^3.4.0",
     "barrelstrength/sprout-base": "^6.0.0",
-    "barrelstrength/sprout-base-sent-email": "^1.1.2"
+    "barrelstrength/sprout-base-sent-email": "^1.1.3"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
It seems that `sprout-base-sent-email` was tagged as 1.1.3 due to the namespace issue but it's calling the older version here.

I have not tested this yet, but wanted to submit it in case it's been overlooked.

https://github.com/barrelstrength/craft-sprout-base-sent-email/commit/585a9d0658c15fb2aa2abda940acd521afade45d

Thanks!